### PR TITLE
update rules scala

### DIFF
--- a/bzl/deps.bzl
+++ b/bzl/deps.bzl
@@ -15,13 +15,13 @@ def djinni_deps():
         ],
         sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     )
-    rules_scala_version = "5.0.0"
+    rules_scala_version = "6.4.0"
     maybe(
         name = "io_bazel_rules_scala",
         repo_rule = http_archive,
         strip_prefix = "rules_scala-{}".format(rules_scala_version),
         url = "https://github.com/bazelbuild/rules_scala/archive/refs/tags/v{}.tar.gz".format(rules_scala_version),
-        sha256 = "141a3919b37c80a846796f792dcf6ea7cd6e7b7ca4297603ca961cd22750c951",
+        sha256 = "9a23058a36183a556a9ba7229b4f204d3e68c8c6eb7b28260521016b38ef4e00",
     )    
     protobuf_version = "3.12.4"
     maybe(


### PR DESCRIPTION
This fixes this error:

```
ERROR: /private/var/tmp/_bazel_stefan/e163f22b8b86a0fc6a37d2590d6618d1/external/io_bazel_rules_scala_scala_library/BUILD:9:13: in scala_import rule @@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_stefan/e163f22b8b86a0fc6a37d2590d6618d1/external/io_bazel_rules_scala/scala/scala_import.bzl", line 34, column 19, in _scala_import_impl
		_stamp_jar(ctx, jar)
	File "/private/var/tmp/_bazel_stefan/e163f22b8b86a0fc6a37d2590d6618d1/external/io_bazel_rules_scala/scala/scala_import.bzl", line 12, column 33, in _stamp_jar
		return java_common.stamp_jar(
	File "/virtual_builtins_bzl/common/java/java_common.bzl", line 117, column 68, in _stamp_jar
Error in _check_java_toolchain_is_declared_on_rule: Rule 'scala_import' in '/private/var/tmp/_bazel_stefan/e163f22b8b86a0fc6a37d2590d6618d1/external/io_bazel_rules_scala_scala_library/BUILD:9:13' must declare '@@bazel_tools//tools/jdk:toolchain_type' toolchain in order to use java_common. See https://github.com/bazelbuild/bazel/issues/18970.
ERROR: /private/var/tmp/_bazel_stefan/e163f22b8b86a0fc6a37d2590d6618d1/external/io_bazel_rules_scala_scala_library/BUILD:9:13: Analysis of target '@@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library' failed
ERROR: Analysis of target '//src:djinni' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.066s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```