### PR TITLE
Kotlin Generator: make CppProxy public

### DIFF
--- a/src/source/KotlinGenerator.scala
+++ b/src/source/KotlinGenerator.scala
@@ -174,7 +174,7 @@ class KotlinGenerator(spec: Spec) extends Generator(spec) {
       val genJavaInterface = spec.javaGenInterface && !statics.nonEmpty && !i.ext.cpp
       val classPrefix = if (genJavaInterface) "interface" else "abstract class"
       val methodPrefix = if (genJavaInterface) "" else "abstract "
-      val innerClassAccessibility = if (genJavaInterface) "" else "private "
+      val innerClassAccessibility = if (genJavaInterface) "" else "public "
 
       w.w(s"$classPrefix $javaClass$typeParamList").braced {
         // Implement the interface's static methods as direct calls to the exported cpp functions.


### PR DESCRIPTION
Make CppProxy public, so that the static method `nativeDestroy` can legally be called from the NativeObjectManager.
Otherwise, this results in IllegalAccessException, for example:

>  Exception in native cleanup of io.openmobilemaps.mapscore.shared.map.LayerInterface.CppProxy: java.lang.IllegalAccessException: class com.snapchat.djinni.NativeObjectManager$NativeObjectWrapper cannot access a member of class io.openmobilemaps.mapscore.shared.map.LayerInterface$CppProxy with modifiers "public static final native"


Note: the Java generator also creates the corresponding inner class as public (`public static final class CppProxy...`).