### PR TITLE
Mark NativeObjectManager as daemon thread to enable clean termination

### DIFF
--- a/support-lib/java/com/snapchat/djinni/NativeObjectManager.java
+++ b/support-lib/java/com/snapchat/djinni/NativeObjectManager.java
@@ -107,6 +107,7 @@ public class NativeObjectManager {
         // NORM_PRIORITY - 1 maps to ANDROID_PRIORITY_BACKGROUND (nice value 10)
         // https://android.googlesource.com/platform/dalvik/+/eclair-release/vm/Thread.c#3057
         mThread.setPriority(Thread.NORM_PRIORITY - 1);
+        mThread.setDaemon(true);
         mThread.start();
     }
 


### PR DESCRIPTION
The NativeObjectManager thread does not terminate on its own. Unless forced by an interrupt, System.exit() or explicitly terminating the NativeObjectManager thread by calling NativeObjectManager.stop(), the JVM never stops. See the Java language documentation on class Thread:

> The Java Virtual Machine continues to execute threads until either of the following occurs:
>
> - The exit method of class Runtime has been called and the security manager has permitted the exit operation to take place.
> - All threads that are not daemon threads have died, either by returning from the call to the run method or by throwing an exception that propagates beyond the run method.

Marking the NativeObjectManager thread as daemon is equivalent to calling NativeObjectManager.stop() explicitly at the end of the last application Thread.