### PR TITLE
Kotlin Generator: fix warning on redundant initialization in compareTo

### DIFF
--- a/src/source/KotlinGenerator.scala
+++ b/src/source/KotlinGenerator.scala
@@ -339,7 +339,7 @@ class KotlinGenerator(spec: Spec) extends Generator(spec) {
 
             w.wl
             w.w(s"override fun compareTo(other: $self): Int").braced {
-              w.wl("var tempResult = 0")
+              w.wl("var tempResult : Int")
               for (f <- r.fields) {
                 f.ty.resolved.base match {
                   case MString | MDate => w.wl(s"tempResult = this.${idJava.field(f.ident)}.compareTo(other.${idJava.field(f.ident)})")


### PR DESCRIPTION
Initializing `var tempResult = 0` in the generated compareTo leads to a kotlin compile time warning "Variable 'tempResult' initializer is redundant".
Fix by only declaring the `tempResult` variable without initialization.