### PR TITLE
Cleanup std library includes in public headers (include what you use)

### DIFF
--- a/support-lib/cpp/DataRef.hpp
+++ b/support-lib/cpp/DataRef.hpp
@@ -22,6 +22,8 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 

--- a/support-lib/cpp/DataView.hpp
+++ b/support-lib/cpp/DataView.hpp
@@ -16,9 +16,8 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <memory>
 
 namespace djinni {
 

--- a/support-lib/cpp/Future.hpp
+++ b/support-lib/cpp/Future.hpp
@@ -18,12 +18,15 @@
 #ifdef __cplusplus
 
 #include <atomic>
-#include <functional>
-#include <memory>
-#include <optional>
-#include <condition_variable>
-#include <mutex>
 #include <cassert>
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <type_traits>
+#include <utility>
 
 #if defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_PTHREADS__) && !defined(NDEBUG)
 #include <pthread.h>

--- a/support-lib/jni/DataRefJNI.cpp
+++ b/support-lib/jni/DataRefJNI.cpp
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <stdexcept>
 #include <variant>
 
 namespace djinni {

--- a/support-lib/jni/DataRefJNI.hpp
+++ b/support-lib/jni/DataRefJNI.hpp
@@ -2,6 +2,9 @@
 #pragma once
 
 #include "../cpp/DataRef.hpp"
+
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/support-lib/jni/DataRef_jni.hpp
+++ b/support-lib/jni/DataRef_jni.hpp
@@ -19,6 +19,8 @@
 #include "djinni_support.hpp"
 #include "DataRefJNI.hpp"
 
+#include <memory>
+
 namespace djinni {
 
 struct NativeDataRef {

--- a/support-lib/jni/DataView_jni.hpp
+++ b/support-lib/jni/DataView_jni.hpp
@@ -19,6 +19,10 @@
 #include "djinni_support.hpp"
 #include "../cpp/DataView.hpp"
 
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
 namespace djinni {
 
 struct NativeDataView {

--- a/support-lib/jni/Future_jni.hpp
+++ b/support-lib/jni/Future_jni.hpp
@@ -20,6 +20,11 @@
 #include "Marshal.hpp"
 #include "../cpp/Future.hpp"
 
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
 namespace djinni {
 
 struct PromiseJniInfo {

--- a/support-lib/jni/Marshal.hpp
+++ b/support-lib/jni/Marshal.hpp
@@ -19,10 +19,14 @@
 #pragma once
 
 #include "djinni_support.hpp"
-#include <array>
+
+#include <cstddef>
+#include <cstdint>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
+#include <limits>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -18,16 +18,21 @@
 
 #pragma once
 
-#include <cassert>
-#include <exception>
-#include <memory>
-#include <mutex>
-#include <string>
-#include <vector>
-
 #include "../proxy_cache_interface.hpp"
 #include "../djinni_common.hpp"
 #include <jni.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 /*
  * Djinni support library

--- a/support-lib/objc/DataRefObjc.hpp
+++ b/support-lib/objc/DataRefObjc.hpp
@@ -20,7 +20,14 @@
 #include "DataRef.hpp"
 
 #include <CoreFoundation/CFData.h>
+
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace djinni {
 

--- a/support-lib/objc/DataView.hpp
+++ b/support-lib/objc/DataView.hpp
@@ -17,9 +17,8 @@
 #pragma once
 #ifdef __cplusplus
 
+#include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <memory>
 
 namespace djinni {
 

--- a/support-lib/objc/Future.hpp
+++ b/support-lib/objc/Future.hpp
@@ -18,12 +18,15 @@
 #ifdef __cplusplus
 
 #include <atomic>
-#include <functional>
-#include <memory>
-#include <optional>
-#include <condition_variable>
-#include <mutex>
 #include <cassert>
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <type_traits>
+#include <utility>
 
 #ifdef __cpp_coroutines
 #if __has_include(<coroutine>)

--- a/support-lib/objc/proxy_cache_impl.hpp
+++ b/support-lib/objc/proxy_cache_impl.hpp
@@ -20,9 +20,13 @@
 #ifdef __cplusplus
 
 #include "proxy_cache_interface.hpp"
-#include <functional>
+
+#include <cstddef>
+#include <memory>
 #include <mutex>
+#include <typeindex>
 #include <unordered_map>
+#include <utility>
 
 // """
 //    This place is not a place of honor.

--- a/support-lib/objc/proxy_cache_interface.hpp
+++ b/support-lib/objc/proxy_cache_interface.hpp
@@ -19,10 +19,11 @@
 #pragma once
 #ifdef __cplusplus
 
+#include <cstddef>
 #include <memory>
-#include <functional>
 #include <typeindex>
 #include <unordered_map>
+#include <utility>
 
 namespace djinni {
 

--- a/support-lib/proxy_cache_impl.hpp
+++ b/support-lib/proxy_cache_impl.hpp
@@ -19,9 +19,13 @@
 #pragma once
 
 #include "proxy_cache_interface.hpp"
-#include <functional>
+
+#include <cstddef>
+#include <memory>
 #include <mutex>
+#include <typeindex>
 #include <unordered_map>
+#include <utility>
 
 // """
 //    This place is not a place of honor.

--- a/support-lib/proxy_cache_interface.hpp
+++ b/support-lib/proxy_cache_interface.hpp
@@ -18,10 +18,11 @@
 
 #pragma once
 #ifdef __cplusplus
+#include <cstddef>
 #include <memory>
-#include <functional>
 #include <typeindex>
 #include <unordered_map>
+#include <utility>
 
 namespace djinni {
 

--- a/support-lib/wasm/DataRefWasm.hpp
+++ b/support-lib/wasm/DataRefWasm.hpp
@@ -19,7 +19,12 @@
 #include "../cpp/DataRef.hpp"
 
 #include "djinni_wasm.hpp"
+
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
 
 namespace djinni {
 class DataRefWasm : public DataRef::PlatformRef {

--- a/support-lib/wasm/DataView_wasm.hpp
+++ b/support-lib/wasm/DataView_wasm.hpp
@@ -19,6 +19,9 @@
 #include "djinni_wasm.hpp"
 #include "../cpp/DataView.hpp"
 
+#include <cstddef>
+#include <cstdint>
+
 namespace djinni {
 
 struct NativeDataView {

--- a/support-lib/wasm/Future_wasm.hpp
+++ b/support-lib/wasm/Future_wasm.hpp
@@ -19,6 +19,10 @@
 #include "djinni_wasm.hpp"
 #include "../cpp/Future.hpp"
 
+#include <exception>
+#include <type_traits>
+#include <utility>
+
 namespace djinni {
 
 template <class RESULT>

--- a/support-lib/wasm/djinni_wasm.hpp
+++ b/support-lib/wasm/djinni_wasm.hpp
@@ -23,12 +23,15 @@
 #include <emscripten/threading.h>
 #endif
 
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <optional>
-#include <stdexcept>
-#include <iostream>
 
 namespace em = emscripten;
 


### PR DESCRIPTION
Prompted by some missing includes, pass over seemingly relevant public headers to "include what you use".